### PR TITLE
SSID password length increased to 64

### DIFF
--- a/SerialESP8266wifi.h
+++ b/SerialESP8266wifi.h
@@ -159,12 +159,12 @@ private:
     
     bool connectToAP();
     char _ssid[16];
-    char _password[16];
+    char _password[64];
     
     bool startLocalAp();
     bool startLocalServer();
     char _localAPSSID[16];
-    char _localAPPassword[16];
+    char _localAPPassword[16]; // may need increasing
     char _localAPChannel[3];
     char _localServerPort[6];
     WifiConnection _connections[MAX_CONNECTIONS];


### PR DESCRIPTION
Local SSID password length left at 16 (this is under our control, we can increase it if we need a longer password for the local AP)